### PR TITLE
Fix "Ambiguous occurrence ‘Vector’" (Data.Vector vs. Diagrams.Prelude.Vector)

### DIFF
--- a/src/Graphics/SVGFonts/ReadFont.hs
+++ b/src/Graphics/SVGFonts/ReadFont.hs
@@ -27,7 +27,6 @@ import           Data.Maybe                      (catMaybes, fromJust,
                                                   fromMaybe, isJust, isNothing,
                                                   maybeToList)
 import           Data.Tuple.Select
-import           Data.Vector                     (Vector)
 import qualified Data.Vector                     as V
 import           Diagrams.Path
 import           Diagrams.Prelude                hiding (font)
@@ -243,7 +242,7 @@ data Kern n = Kern
   , kernU2S :: Map.Map String [Int]
   , kernG1S :: Map.Map String [Int]
   , kernG2S :: Map.Map String [Int]
-  , kernK   :: Vector n
+  , kernK   :: V.Vector n
   } deriving (Show, Generic)
 
 instance Serialize n => Serialize (Kern n)


### PR DESCRIPTION
Fixes

```
    SVGFonts/src/Graphics/SVGFonts/ReadFont.hs:246:16: error:
        Ambiguous occurrence ‘Vector’
        It could refer to either ‘V.Vector’,
                                 imported from ‘Data.Vector’ at src/Graphics/SVGFonts/ReadFont.hs:30:51-56
                              or ‘Diagrams.Prelude.Vector’,
                                 imported from ‘Diagrams.Prelude’ at src/Graphics/SVGFonts/ReadFont.hs:33:1-62
                                 (and originally defined in ‘Data.Vector.Unboxed.Base’)
```